### PR TITLE
added whyrun_supported? to resource provider

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -1,3 +1,7 @@
+def whyrun_supported?
+  true
+end
+
 action :create do
   directory node['limits']['conf_dir'] do
     mode 0755


### PR DESCRIPTION
It looks like there is no reason atm to restrict provider from supporting why_run mode so here is a pullrequest for that.
