### PR TITLE
Add support for Chef 16.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 limits cookbook CHANGELOG
 =========================
 
+v2.1.1 (2020-06-22)
+-------------------
+
+* Chef 16.2.x had a backwards-incompatible change related to custom
+  resources. This version supports the new style while maintaining
+  backwards-compatibility.
+* Update Chef Workstation to 20.6.62
+
 v2.1.0 (2020-05-15)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -165,16 +165,16 @@ end
 Testing
 =======
 
-Testing was performed using [Chef Workstation 0.18.3][4].
+Testing was performed using [Chef Workstation 20.6.62][4].
 
 ```
 $ chef --version
-Chef Workstation version: 0.18.3
-Chef Infra Client version: 15.10.12
-Chef InSpec version: 4.18.111
-Chef CLI version: 2.0.10
-Test Kitchen version: 2.5.0
-Cookstyle version: 6.3.4
+Chef Workstation version: 20.6.62
+Chef Infra Client version: 16.1.16
+Chef InSpec version: 4.19.0
+Chef CLI version: 3.0.4
+Test Kitchen version: 2.5.1
+Cookstyle version: 6.7.3
 ```
 
 Perform tests using the following commands:
@@ -189,4 +189,4 @@ chef exec kitchen test    # integration tests
 [1]: https://supermarket.chef.io/cookbooks/limits
 [2]: https://github.com/jrwesolo/limits
 [3]: https://linux.die.net/man/5/limits.conf
-[4]: https://downloads.chef.io/chef-workstation/stable/0.18.3
+[4]: https://downloads.chef.io/chef-workstation/stable/20.6.62

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -32,11 +32,11 @@ platforms:
 - name: centos-7-chef-15
   driver:
     image: dokken/centos-7
-    chef_version: 15.10.12
+    chef_version: 15.11.8
 - name: centos-7-chef-16
   driver:
     image: dokken/centos-7
-    chef_version: 16.1.0
+    chef_version: 16.2.44
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Jordan Wesolowski'
 maintainer_email 'N/A'
 license          'MIT'
 description      'Configures limits for the pam_limits module'
-version          '2.1.0'
+version          '2.1.1'
 chef_version     '>= 12', '< 17'
 
 # The `source_url` points to the development repository for this cookbook.  A

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -1,4 +1,5 @@
-resource_name :limits_file
+resource_name :limits_file # backwards-compatibility for Chef < 16
+provides :limits_file
 
 property :path, String, name_property: true
 property :owner, [String, Integer], default: 'root'

--- a/resources/limit.rb
+++ b/resources/limit.rb
@@ -1,4 +1,5 @@
-resource_name :limit
+resource_name :limit # backwards-compatibility for Chef < 16
+provides :limit
 
 property :path,
          String,


### PR DESCRIPTION
* Chef 16.2.x had a backwards-incompatible change related to custom
  resources. This version supports the new style while maintaining
  backwards-compatibility.
* Update Chef Workstation to 20.6.62

Fixes #18 