### PR TITLE
Add support for Chef 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,32 @@
 limits cookbook CHANGELOG
 =========================
 
-v2.1.1 (2020-06-22)
--------------------
+[v2.2.0][] (2020-12-30)
+-----------------------
+
+* Add support for Chef 17
+* Update Chef Workstation to 20.12.205
+* Cookstyle-recommended fixes
+* Test kitchen will test more platforms
+* Test kitchen will perform two converges and ensure idempotency
+* Add TESTING.md file
+
+[v2.1.1][] (2020-06-22)
+-----------------------
 
 * Chef 16.2.x had a backwards-incompatible change related to custom
   resources. This version supports the new style while maintaining
   backwards-compatibility.
 * Update Chef Workstation to 20.6.62
 
-v2.1.0 (2020-05-15)
--------------------
+[v2.1.0][] (2020-05-15)
+-----------------------
 
 * Add support for Chef 16.x
 * Update Chef Workstation to 0.18.3
 
-v2.0.0 (2019-06-04)
--------------------
+[v2.0.0][] (2019-06-04)
+-----------------------
 
 This cookbook has been completely refactored. It is not backwards
 compatible. Please see the `README.md` for usage details. The code has
@@ -34,8 +44,8 @@ removed in favor of the new custom resource syntax introduced in Chef
 * Replace Vagrant with Dokken
 * Test support on Chef 12-15
 
-v1.0.0 (2014-12-07)
--------------------
+[v1.0.0][] (2014-12-07)
+-----------------------
 
 This cookbook has changed to be an LWRP-only usage. No longer will
 limits be able to be specified using attributes. Please see the
@@ -46,7 +56,14 @@ limits be able to be specified using attributes. Please see the
 * Add Serverspec tests
 * Change license from Apache to MIT
 
-v0.2.0 (2014-04-09)
--------------------
+[v0.2.0][] (2014-04-09)
+-----------------------
 
 * Initial release of limits
+
+[v2.2.0]: https://github.com/jrwesolo/limits/tree/v2.2.0
+[v2.1.1]: https://github.com/jrwesolo/limits/tree/v2.1.1
+[v2.1.0]: https://github.com/jrwesolo/limits/tree/v2.1.0
+[v2.0.0]: https://github.com/jrwesolo/limits/tree/v2.0.0
+[v1.0.0]: https://github.com/jrwesolo/limits/tree/v1.0.0
+[v0.2.0]: https://github.com/jrwesolo/limits/tree/v0.2.0

--- a/README.md
+++ b/README.md
@@ -162,31 +162,6 @@ limit 'delete example' do
 end
 ```
 
-Testing
-=======
-
-Testing was performed using [Chef Workstation 20.6.62][4].
-
-```
-$ chef --version
-Chef Workstation version: 20.6.62
-Chef Infra Client version: 16.1.16
-Chef InSpec version: 4.19.0
-Chef CLI version: 3.0.4
-Test Kitchen version: 2.5.1
-Cookstyle version: 6.7.3
-```
-
-Perform tests using the following commands:
-
-```bash
-chef exec foodcritic .    # linting for common issues
-chef exec cookstyle       # linting based on RuboCop
-chef exec rspec           # spec tests
-chef exec kitchen test    # integration tests
-```
-
 [1]: https://supermarket.chef.io/cookbooks/limits
 [2]: https://github.com/jrwesolo/limits
 [3]: https://linux.die.net/man/5/limits.conf
-[4]: https://downloads.chef.io/chef-workstation/stable/20.6.62

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,25 @@
+Testing
+=======
+
+Testing was performed using [Chef Workstation 20.12.205][1].
+
+```
+$ chef --version
+Chef Workstation version: 20.12.205
+Chef Infra Client version: 16.8.14
+Chef InSpec version: 4.24.8
+Chef CLI version: 3.0.33
+Chef Habitat version: 1.6.181
+Test Kitchen version: 2.8.0
+Cookstyle version: 7.3.11
+```
+
+Perform tests using the following commands:
+
+```bash
+chef exec cookstyle    # linting
+chef exec rspec        # spec tests
+chef exec kitchen test # integration tests
+```
+
+[1]: https://downloads.chef.io/products/workstation/stable?v=20.12.205

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -8,35 +8,71 @@ transport:
 provisioner:
   name: dokken
   deprecations_as_errors: true
+  enforce_idempotency: true
+  multiple_converge: 2
 
 verifier:
   name: inspec
 
-# Most recent stable release for each
-# major version will be tested below:
-# https://downloads.chef.io/chef/stable
+# using latest OS version created for use with Dokken:
+# https://hub.docker.com/u/dokken
+.os_images:
+- &centos dokken/centos-8
+- &debian dokken/debian-10
+- &fedora dokken/fedora-33
+- &ubuntu dokken/ubuntu-20.10
 
+# using latest stable from each major version when
+# generally available, otherwise using latest current:
+# https://downloads.chef.io/products/infra-client/stable
+# https://downloads.chef.io/products/infra-client/current
+.chef_versions:
+- &chef_12 12.22.5
+- &chef_13 13.12.14
+- &chef_14 14.15.6
+- &chef_15 15.13.8
+- &chef_16 16.8.14 # latest stable
+- &chef_17 17.0.3 # in development
+
+# test all major Chef versions on single OS and
+# latest stable Chef version on all other OS:
 platforms:
-- name: centos-7-chef-12
+- name: debian-chef-12
   driver:
-    image: dokken/centos-7
-    chef_version: 12.22.5
-- name: centos-7-chef-13
+    image: *debian
+    chef_version: *chef_12
+- name: debian-chef-13
   driver:
-    image: dokken/centos-7
-    chef_version: 13.12.14
-- name: centos-7-chef-14
+    image: *debian
+    chef_version: *chef_13
+- name: debian-chef-14
   driver:
-    image: dokken/centos-7
-    chef_version: 14.15.6
-- name: centos-7-chef-15
+    image: *debian
+    chef_version: *chef_14
+- name: debian-chef-15
   driver:
-    image: dokken/centos-7
-    chef_version: 15.11.8
-- name: centos-7-chef-16
+    image: *debian
+    chef_version: *chef_15
+- name: debian-chef-16
   driver:
-    image: dokken/centos-7
-    chef_version: 16.2.44
+    image: *debian
+    chef_version: *chef_16
+- name: debian-chef-17
+  driver:
+    image: *debian
+    chef_version: *chef_17
+- name: centos-chef-16
+  driver:
+    image: *centos
+    chef_version: *chef_16
+- name: fedora-chef-16
+  driver:
+    image: *fedora
+    chef_version: *chef_16
+- name: ubuntu-chef-16
+  driver:
+    image: *ubuntu
+    chef_version: *chef_16
 
 suites:
   - name: default

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -7,7 +7,7 @@ module Limits
 
     # Removing leading '#' and optional space from each line.
     def self.normalize_comment(comment)
-      return nil unless comment
+      return unless comment
 
       lines = comment.lines.map(&:chomp)
       lines.map! { |line| line.sub(/^#[ \t]?/, '') }
@@ -19,7 +19,7 @@ module Limits
     # there is anything afterwards. Trailing whitespace is also removed.
     # Comment will always end in a newline for proper formatting.
     def self.format_comment(comment)
-      return nil unless comment
+      return unless comment
 
       lines = comment.lines.map(&:chomp)
       lines.push('') if comment.end_with?("\n")

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,8 +3,8 @@ maintainer       'Jordan Wesolowski'
 maintainer_email 'N/A'
 license          'MIT'
 description      'Configures limits for the pam_limits module'
-version          '2.1.1'
-chef_version     '>= 12', '< 17'
+version          '2.2.0'
+chef_version     '>= 12', '< 18'
 
 # The `source_url` points to the development repository for this cookbook.  A
 # `View Source` link will be displayed on this cookbook's page when uploaded to

--- a/resources/limit.rb
+++ b/resources/limit.rb
@@ -14,11 +14,13 @@ property :domain,
          callbacks: { 'should not be empty' => ->(x) { !x.empty? } }
 
 property :type,
+         String,
          equal_to: Limits::TYPES,
          required: true,
          identity: true
 
 property :item,
+         String,
          equal_to: Limits::ITEMS,
          required: true,
          identity: true

--- a/test/fixtures/cookbooks/limits_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/limits_test/attributes/default.rb
@@ -1,0 +1,5 @@
+default['setup']['owner'] = 'nobody'
+default['setup']['group'] = value_for_platform_family(
+  'debian' => 'nogroup',
+  'default' => 'nobody'
+)

--- a/test/fixtures/cookbooks/limits_test/recipes/setup.rb
+++ b/test/fixtures/cookbooks/limits_test/recipes/setup.rb
@@ -11,8 +11,8 @@ files_for_setup = %w(
 files_for_setup.each do |path|
   cookbook_file path do
     source ::File.basename(path)
-    owner 'nobody'
-    group 'nobody'
+    owner node['setup']['owner']
+    group node['setup']['group']
     mode '0755'
     backup false
     action :create


### PR DESCRIPTION
* Add support for Chef 17
* Update Chef Workstation to 20.12.205
* Cookstyle-recommended fixes
* Test kitchen will test more platforms
* Test kitchen will perform two converges and ensure idempotency
* Add TESTING.md file