### PR TITLE
Add support for Chef Infra Client 18

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-group :integration do
-  cookbook 'limits_test', path: 'test/fixtures/cookbooks/limits_test'
-end
-
-metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 limits cookbook CHANGELOG
 =========================
 
-[v2.2.1][] (2022-11-04)
+[v2.3.0][] (2022-11-04)
 -----------------------
-* Added testing for Chef Infra Client 18
 
+* Add support for Chef Infra Client 18
+* Update Chef Workstation to 22.10.1013
+* Update platform versions for Test Kitchen
+* Update Chef Infra Client versions for Test Kitchen
+* Move to policy files for Test Kitchen
+* Cookstyle-recommended fixes
 
 [v2.2.0][] (2020-12-30)
 -----------------------
@@ -66,6 +71,7 @@ limits be able to be specified using attributes. Please see the
 
 * Initial release of limits
 
+[v2.3.0]: https://github.com/jrwesolo/limits/tree/v2.3.0
 [v2.2.0]: https://github.com/jrwesolo/limits/tree/v2.2.0
 [v2.1.1]: https://github.com/jrwesolo/limits/tree/v2.1.1
 [v2.1.0]: https://github.com/jrwesolo/limits/tree/v2.1.0

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,7 @@
+name 'limits_test'
+run_list 'limits_test'
+
+default_source :supermarket
+
+cookbook 'limits', path: '.'
+cookbook 'limits_test', path: './test/fixtures/cookbooks/limits_test'

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,17 +1,17 @@
 Testing
 =======
 
-Testing was performed using [Chef Workstation 20.12.205][1].
+Testing was performed using [Chef Workstation 22.10.1013][1].
 
 ```
 $ chef --version
-Chef Workstation version: 20.12.205
-Chef Infra Client version: 16.8.14
-Chef InSpec version: 4.24.8
-Chef CLI version: 3.0.33
-Chef Habitat version: 1.6.181
-Test Kitchen version: 2.8.0
-Cookstyle version: 7.3.11
+Chef Workstation version: 22.10.1013
+Chef Infra Client version: 17.10.0
+Chef InSpec version: 4.56.20
+Chef CLI version: 5.6.1
+Chef Habitat version: 1.6.521
+Test Kitchen version: 3.3.2
+Cookstyle version: 7.32.1
 ```
 
 Perform tests using the following commands:
@@ -22,4 +22,4 @@ chef exec rspec        # spec tests
 chef exec kitchen test # integration tests
 ```
 
-[1]: https://downloads.chef.io/products/workstation/stable?v=20.12.205
+[1]: https://www.chef.io/downloads/tools/workstation?v=22.10.1013

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,23 +17,23 @@ verifier:
 # using latest OS version created for use with Dokken:
 # https://hub.docker.com/u/dokken
 .os_images:
-- &centos dokken/centos-8
-- &debian dokken/debian-10
-- &fedora dokken/fedora-33
-- &ubuntu dokken/ubuntu-20.10
+- &centos dokken/centos-stream-9
+- &debian dokken/debian-11
+- &fedora dokken/fedora-36
+- &ubuntu dokken/ubuntu-22.10
 
 # using latest stable from each major version when
 # generally available, otherwise using latest current:
-# https://downloads.chef.io/products/infra-client/stable
-# https://downloads.chef.io/products/infra-client/current
+# https://www.chef.io/downloads/tools/infra-client
+# https://www.chef.io/downloads/tools/infra-client/current
 .chef_versions:
 - &chef_12 12.22.5
 - &chef_13 13.12.14
 - &chef_14 14.15.6
-- &chef_15 15.13.8
-- &chef_16 16.8.14 
-- &chef_17 17.0.3 
-- &chef_18 18.0.169 # latest stable
+- &chef_15 15.17.4
+- &chef_16 16.18.0
+- &chef_17 17.10.3
+- &chef_18 18.0.169
 
 # test all major Chef versions on single OS and
 # latest stable Chef version on all other OS:
@@ -66,26 +66,14 @@ platforms:
   driver:
     image: *debian
     chef_version: *chef_18
-- name: centos-chef-16
-  driver:
-    image: *centos
-    chef_version: *chef_16
 - name: centos-chef-18
   driver:
     image: *centos
     chef_version: *chef_18
-- name: fedora-chef-16
-  driver:
-    image: *fedora
-    chef_version: *chef_16
 - name: fedora-chef-18
   driver:
     image: *fedora
     chef_version: *chef_18
-- name: ubuntu-chef-16
-  driver:
-    image: *ubuntu
-    chef_version: *chef_16
 - name: ubuntu-chef-18
   driver:
     image: *ubuntu
@@ -93,5 +81,3 @@ platforms:
 
 suites:
   - name: default
-    run_list:
-      - recipe[limits_test]

--- a/libraries/file.rb
+++ b/libraries/file.rb
@@ -34,7 +34,7 @@ module Limits
     end
 
     def write!
-      ::File.open(@path, 'w') { |file| file.write(self) }
+      ::File.write(@path, self)
     end
 
     def add(new)

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Jordan Wesolowski'
 maintainer_email 'N/A'
 license          'MIT'
 description      'Configures limits for the pam_limits module'
-version          '2.2.1'
+version          '2.3.0'
 chef_version     '>= 12', '< 19'
 
 # The `source_url` points to the development repository for this cookbook.  A

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -1,3 +1,5 @@
+unified_mode true if Chef::VERSION.to_f >= 15.3
+
 resource_name :limits_file # backwards-compatibility for Chef < 16
 provides :limits_file
 

--- a/resources/limit.rb
+++ b/resources/limit.rb
@@ -1,3 +1,5 @@
+unified_mode true if Chef::VERSION.to_f >= 15.3
+
 resource_name :limit # backwards-compatibility for Chef < 16
 provides :limit
 


### PR DESCRIPTION
* Add support for Chef Infra Client 18
* Update Chef Workstation to 22.10.1013
* Update platform versions for Test Kitchen
* Update Chef Infra Client versions for Test Kitchen
* Move to policy files for Test Kitchen
* Cookstyle-recommended fixes