### PR TITLE
Add support for Chef 19

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,17 +1,17 @@
 Testing
 =======
 
-Testing was performed using [Chef Workstation 22.10.1013][1].
+Testing was performed using [Chef Workstation 25.13.7][1].
 
 ```
 $ chef --version
-Chef Workstation version: 22.10.1013
-Chef Infra Client version: 17.10.0
-Chef InSpec version: 4.56.20
-Chef CLI version: 5.6.1
-Chef Habitat version: 1.6.521
-Test Kitchen version: 3.3.2
-Cookstyle version: 7.32.1
+Chef Workstation version: 25.13.7
+Chef CLI version: 5.6.23
+Chef Habitat version: 1.6.1243
+Test Kitchen version: 3.9.1
+Cookstyle version: 7.32.8
+Chef Infra Client version: 18.10.17
+Chef InSpec version: 5.24.7
 ```
 
 Perform tests using the following commands:
@@ -22,4 +22,4 @@ chef exec rspec        # spec tests
 chef exec kitchen test # integration tests
 ```
 
-[1]: https://www.chef.io/downloads/tools/workstation?v=22.10.1013
+[1]: https://docs.chef.io/workstation/25/install/

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -13,71 +13,33 @@ provisioner:
 
 verifier:
   name: inspec
+  inspec_tests:
+    - test/integration/default
 
-# using latest OS version created for use with Dokken:
-# https://hub.docker.com/u/dokken
-.os_images:
-- &centos dokken/centos-stream-9
-- &debian dokken/debian-11
-- &fedora dokken/fedora-36
-- &ubuntu dokken/ubuntu-22.10
-
-# using latest stable from each major version when
-# generally available, otherwise using latest current:
-# https://www.chef.io/downloads/tools/infra-client
-# https://www.chef.io/downloads/tools/infra-client/current
-.chef_versions:
-- &chef_12 12.22.5
-- &chef_13 13.12.14
-- &chef_14 14.15.6
-- &chef_15 15.17.4
-- &chef_16 16.18.0
-- &chef_17 17.10.3
-- &chef_18 18.0.169
-
-# test all major Chef versions on single OS and
-# latest stable Chef version on all other OS:
 platforms:
-- name: debian-chef-12
+- name: debian
   driver:
-    image: *debian
-    chef_version: *chef_12
-- name: debian-chef-13
+    image: dokken/debian-13
+- name: centos
   driver:
-    image: *debian
-    chef_version: *chef_13
-- name: debian-chef-14
+    image: dokken/centos-stream-10
+- name: fedora
   driver:
-    image: *debian
-    chef_version: *chef_14
-- name: debian-chef-15
+    image: dokken/fedora-43
+- name: ubuntu
   driver:
-    image: *debian
-    chef_version: *chef_15
-- name: debian-chef-16
-  driver:
-    image: *debian
-    chef_version: *chef_16
-- name: debian-chef-17
-  driver:
-    image: *debian
-    chef_version: *chef_17
-- name: debian-chef-18
-  driver:
-    image: *debian
-    chef_version: *chef_18
-- name: centos-chef-18
-  driver:
-    image: *centos
-    chef_version: *chef_18
-- name: fedora-chef-18
-  driver:
-    image: *fedora
-    chef_version: *chef_18
-- name: ubuntu-chef-18
-  driver:
-    image: *ubuntu
-    chef_version: *chef_18
+    image: dokken/ubuntu-25.10
 
 suites:
-  - name: default
+  - name: chef-19
+    driver:
+      chef_image: chef/chef-hab
+      chef_version: 19.2.77
+    provisioner:
+      chef_binary: /hab/pkgs/chef/chef-infra-client/19.2.77/20260414044356/bin/chef-client
+  - name: chef-18
+    driver:
+      chef_version: 18.10.47
+  - name: chef-17
+    driver:
+      chef_version: 17.10.163

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,8 +3,8 @@ maintainer       'Jordan Wesolowski'
 maintainer_email 'N/A'
 license          'MIT'
 description      'Configures limits for the pam_limits module'
-version          '2.3.0'
-chef_version     '>= 12', '< 19'
+version          '2.4.0'
+chef_version     '>= 12', '< 20'
 
 # The `source_url` points to the development repository for this cookbook.  A
 # `View Source` link will be displayed on this cookbook's page when uploaded to


### PR DESCRIPTION
* Add support for Chef 19
* Refactor platform/suites for Test Kitchen
* Update platforms and Chef versions for Test Kitchen

Note: Chef 19 is no longer being provided as a chef/chef Docker image. Instead, it is being provided via the chef/chef-hab Docker image. Dokken does not natively support using this hab-based Chef install so we have to override the Chef image being used and specify an image-specific Chef binary. This works fine on Apple Silicon, but it is unclear if this binary path will be the same between different architectures.

Fixes #23